### PR TITLE
Use generic issues forms

### DIFF
--- a/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/ISSUE_TEMPLATE/1-bug-report.yml
@@ -1,0 +1,56 @@
+name: 'Bug report'
+labels: ['bug', 'triage']
+description: Create a report to help Kubewarden to improve
+body:
+- type: checkboxes
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please search to see if an issue already exists for the bug you encountered.
+    options:
+    - label: I have searched the existing issues
+      required: true
+- type: textarea
+  attributes:
+    label: Current Behavior
+    description: A concise description of what you're experiencing.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Expected Behavior
+    description: A concise description of what you expected to happen.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Steps To Reproduce
+    description: Steps to reproduce the behavior.
+    placeholder: |
+      1. In this environment...
+      2. With this config...
+      3. Run '...'
+      4. See error...
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Environment
+    description: |
+      examples:
+        - **OS**: Linux
+        - **Architecture**: arm64
+    value: |
+        - OS:
+        - Architecture:
+    render: markdown
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Anything else?
+    description: |
+      Links? References? Screenshots? Anything that will give us more context about the issue you are encountering!
+
+      Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+  validations:
+    required: false

--- a/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/ISSUE_TEMPLATE/2-feature-request.yml
@@ -1,0 +1,32 @@
+name: 'Feature Request'
+labels: ['triage']
+description: Create a feature request to help Kubewarden to improve
+title: 'Feature Request: '
+body:
+- type: textarea
+  attributes:
+    label: Is your feature request related to a problem?
+    description: A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Solution you'd like
+    description: A clear and concise description of what you want to happen
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Alternatives you've considered
+    description: A clear and concise description of any alternative solutions or features you've considered
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Anything else?
+    description: |
+      Links? References? Screenshots? Anything that will give us more context about the issue you are encountering!
+
+      Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+  validations:
+    required: false

--- a/ISSUE_TEMPLATE/config.yml
+++ b/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true


### PR DESCRIPTION
Introduce generic issues using the issue forms

You can look on this repository https://github.com/updatecli/updatecli/issues/new/choose what it looks like

More information can be found on GitHub [documentation](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms)

It's important to keep in mind that this generic template will be used by all repositories in the Kubewarden organisation

Signed-off-by: Olivier Vernin <olivier.vernin@suse.com>