### PR TITLE
Create CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# CONTRIBUTING
+
+Thanks, for your interest in contributing to Kubewarden.
+
+They are different ways you could help us simplify the adoption of policy as code.
+
+## Feedback
+
+* Starring our main repository [kubewarden/policy-server](https://github.com/kubewarden/policy-server). GitHub stars do matter !
+* Joining us on our [`kubewarden` channel](https://kubernetes.slack.com/?redir=%2Fmessages%2Fkubewarden).
+* Following us on [Twitter](https://twitter.com/kubewarden).
+
+## Code 
+
+Contributing to our [policy templates](https://github.com/topics/kubewarden-policy-template), [policy SDKs](https://github.com/topics/kubewarden-policy-sdk) and [policies](https://github.com/topics/kubewarden-policy).
+You could also look into the following "core" projects:
+
+| Project | Scope | Language |
+|---------|---------|--------|
+| [`kubewarden-controller`](https://github.com/kubewarden/kubewarden-controller) | Kubernetes integration point| Go |
+| [`policy-server`](https://github.com/kubewarden/policy-server) | Run Kubewarden policies | Rust |
+| [`kwctl`](https://github.com/kubewarden/kwctl) | Kubewarden policy multi-purpose cli tool | Rust |
+
+## Mission
+
+Help us make Kubernetes cluster a more secure place by adopting policy as code.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # CONTRIBUTING
 
-Thanks, for your interest in contributing to Kubewarden.
+Thanks for your interest in contributing to Kubewarden.
 
 They are different ways you could help us simplify the adoption of policy as code.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks for your interest in contributing to Kubewarden.
 
-They are different ways you could help us simplify the adoption of policy as code.
+There are different ways you could help us simplify the adoption of policy as code.
 
 ## Feedback
 


### PR DESCRIPTION
I propose to create a default contributing file that would be used by all git repositories.

I am trying to stay as generic as possible while suggesting other ways to contribute to Kubewarden without necessary writing code.

Because they are specificities for some git repositories, I don't think having different CONTRIBUTING files per repo will work on the long term. I would suggest for future improvement to have a contributing section on  www.kubewarden.io so we could just redirect contributors there.
