### PR TITLE
Update Policy Hub link to ArtifactHub

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -13,7 +13,7 @@ Get in touch with us on Slack: join the [`kubewarden` channel](https://kubernete
 
 ## Enforcing Policies 🔒
 
-Discover ready to use policies by visiting the [Policy Hub](https://hub.kubewarden.io) 📦
+Discover ready to use policies by visiting the [Policy Hub](https://artifacthub.io/packages/search?kind=13&sort=relevance&page=1) 📦
 
 Don't forget to take a look at [`kwctl`](https://github.com/kubewarden/kwctl), our handy multi-purpose tool for managing policies 🛠️ 🧰
 


### PR DESCRIPTION
This pull request includes a single change to update a link in the `profile/README.md` file. The link now directs users to the correct location for discovering ready-to-use policies.

* <a href="diffhunk://#diff-0e83982cf6f4dabedcbf7b12029a56c6f4a728064ba99543fff8f227c0654b45L16-R16">`profile/README.md`</a>: Updated the link to the Policy Hub to direct users to the correct location for discovering ready-to-use policies.