### PR TITLE
fix(docs): update/correct .NET links

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -4,7 +4,6 @@ Kubewarden policies can be written using regular programming languages or Domain
 
 Policies are compiled into [WebAssembly](https://webassembly.org/) modules that are then distributed using traditional [container registries](https://landscape.cncf.io/card-mode?category=container-registry&grouping=category).
 
-
 ## Getting Started 📚
 
 Check our first-stop [kubewarden/community](https://github.com/kubewarden/community) 👋 repository for information about the organization of the project.
@@ -34,8 +33,7 @@ Interested in writing a new policy?
 | Swift | [:octocat:](https://github.com/kubewarden/swift-policy-template) | [:octocat:](https://github.com/kubewarden/policy-sdk-swift) | ✔️ | ✔️ | ↗️ |
 | Rego - Open Policy Agent | [:octocat:](https://github.com/kubewarden/opa-policy-template) | [Rego built-ins](https://www.openpolicyagent.org/docs/latest/policy-reference/#built-in-functions) | ✔️ | ❌ | 🔝 |
 | Rego - Gatekeeper | [:octocat:](https://github.com/kubewarden/gatekeeper-policy-template) | [Rego built-ins](https://www.openpolicyagent.org/docs/latest/policy-reference/#built-in-functions) | ✔️ | ❌ | 🔝 |
-| DotNet     |❌  | [:octocat:](https://github.com/kubewarden/policy-sdk-rust) | ✔️ | ✔️ | ↗️  |
-
+| DotNet     | [:octocat:](https://github.com/kubewarden/dotnet-policy-template)  | [:octocat:](https://github.com/kubewarden/policy-sdk-dotnet) | ✔️ | ✔️ | ↗️  |
 
 Can't find your favorite language? 🔍 Reach out to us and let's have a chat!
 
@@ -62,7 +60,3 @@ Quick links to "core" projects:
 | [`kubewarden-controller`](https://github.com/kubewarden/kubewarden-controller/contribute) | Kubernetes integration point| Go |
 | [`policy-server`](https://github.com/kubewarden/policy-server/contribute) | Run Kubewarden policies | Rust |
 | [`kwctl`](https://github.com/kubewarden/kwctl/contribute) | Kubewarden policy multi-purpose cli tool | Rust |
-
-
-
-


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

Update and correct the .NET  SDK and template links
- the [policy template](https://github.com/kubewarden/dotnet-policy-template) wasn't linked
- the [policy SDK](https://github.com/kubewarden/policy-sdk-dotnet) incorrectly linked to the Rust one

- misc `markdownlint` newline autofixes

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

See the rendered markdown [rich diff](https://github.com/kubewarden/.github/pull/19/files?short_path=0e83982#diff-0e83982cf6f4dabedcbf7b12029a56c6f4a728064ba99543fff8f227c0654b45)

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

n/a

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

n/a