### PR TITLE
docs: condense "Writing policies" section

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -23,7 +23,12 @@ Don't forget to take a look at [`kwctl`](https://github.com/kubewarden/kwctl), o
 
 Interested in writing a new policy?
 
-Checkout the [step-by-step tutorials](https://docs.kubewarden.io/tutorials/writing-policies) inside of our documentation 📖
+Kubewarden allows you to write policies using a variety of programming languages, including Rust, Go, Rego, CEL and others.
+
+These are some useful resources to get you started:
+ - [Step-by-step tutorials](https://docs.kubewarden.io/tutorials/writing-policies) inside of our documentation 📖
+ - [Policy SDK](https://github.com/kubewarden/community/#policies-sdks): overview of the Policy SDKs available, and their maturity level 📚
+ - [Policy templates](https://github.com/kubewarden/community/#policies-templates): boilerplate code to help you get started 🚀  
 
 ## Useful GitHub tags :octocat: 🏷️
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -4,7 +4,6 @@ Kubewarden policies can be written using regular programming languages or Domain
 
 Policies are compiled into [WebAssembly](https://webassembly.org/) modules that are then distributed using traditional [container registries](https://landscape.cncf.io/card-mode?category=container-registry&grouping=category).
 
-
 ## Getting Started 📚
 
 Check our first-stop [kubewarden/community](https://github.com/kubewarden/community) 👋 repository for information about the organization of the project.
@@ -23,21 +22,8 @@ Don't forget to take a look at [`kwctl`](https://github.com/kubewarden/kwctl), o
 ## Writing policies 📝
 
 Interested in writing a new policy?
-  1. Checkout the step-by-step tutorials inside of our [documentation](https://docs.kubewarden.io) 📖
-  1. Add [`kwctl`](https://github.com/kubewarden/kwctl) to your toolbox 🛠️ 🧰
-  1. Pick one of the languages from below
 
-| Language | Project Template | SDK | Validation | Mutation | Maturity |
-|----------|------------------|-----|------------|----------|----------|
-| Rust     | [:octocat:](https://github.com/kubewarden/rust-policy-template) | [:octocat:](https://github.com/kubewarden/policy-sdk-rust) | ✔️ | ✔️ | 🔝 |
-| Go ([TinyGo](https://tinygo.org/)) | [:octocat:](https://github.com/kubewarden/go-policy-template) | [:octocat:](https://github.com/kubewarden/policy-sdk-go) | ✔️ | ✔️ | ↗️ |
-| Swift | [:octocat:](https://github.com/kubewarden/swift-policy-template) | [:octocat:](https://github.com/kubewarden/policy-sdk-swift) | ✔️ | ✔️ | ↗️ |
-| Rego - Open Policy Agent | [:octocat:](https://github.com/kubewarden/opa-policy-template) | [Rego built-ins](https://www.openpolicyagent.org/docs/latest/policy-reference/#built-in-functions) | ✔️ | ❌ | 🔝 |
-| Rego - Gatekeeper | [:octocat:](https://github.com/kubewarden/gatekeeper-policy-template) | [Rego built-ins](https://www.openpolicyagent.org/docs/latest/policy-reference/#built-in-functions) | ✔️ | ❌ | 🔝 |
-| DotNet     |❌  | [:octocat:](https://github.com/kubewarden/policy-sdk-rust) | ✔️ | ✔️ | ↗️  |
-
-
-Can't find your favorite language? 🔍 Reach out to us and let's have a chat!
+Checkout the [step-by-step tutorials](https://docs.kubewarden.io/tutorials/writing-policies) inside of our documentation 📖
 
 ## Useful GitHub tags :octocat: 🏷️
 
@@ -62,7 +48,3 @@ Quick links to "core" projects:
 | [`kubewarden-controller`](https://github.com/kubewarden/kubewarden-controller/contribute) | Kubernetes integration point| Go |
 | [`policy-server`](https://github.com/kubewarden/policy-server/contribute) | Run Kubewarden policies | Rust |
 | [`kwctl`](https://github.com/kubewarden/kwctl/contribute) | Kubewarden policy multi-purpose cli tool | Rust |
-
-
-
-


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

Closes #19 by heavily condensing the section in general instead of fixing outdated links, based on the discussion there

- link out to the [docs page on "Writing Policies"](https://docs.kubewarden.io/tutorials/writing-policies) instead

- misc `markdownlint` newline autofixes

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

See the [rendered markdown](https://github.com/kubewarden/.github/blob/8d1cd8bbd77013ad9bd71bc06954a16b9c4fb718/profile/README.md#writing-policies-)

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

n/a

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

n/a
